### PR TITLE
feat: add light mode

### DIFF
--- a/src/browser/cn.ts
+++ b/src/browser/cn.ts
@@ -4,3 +4,36 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Compute perceived lightness of a hex color (0–1).
+ * Uses sRGB relative luminance formula.
+ */
+function perceivedLightness(hex: string): number {
+  const r = parseInt(hex.slice(0, 2), 16) / 255;
+  const g = parseInt(hex.slice(2, 4), 16) / 255;
+  const b = parseInt(hex.slice(4, 6), 16) / 255;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Returns inline styles for a GitHub-style label.
+ * In light mode, light-colored labels get a solid background with dark text
+ * so they remain visible against a white page background.
+ */
+export function labelStyles(color: string): React.CSSProperties {
+  const isLight = document.documentElement.classList.contains("light");
+  const l = perceivedLightness(color);
+  if (isLight && l > 0.6) {
+    return {
+      backgroundColor: `#${color}`,
+      color: "#1f2328",
+      border: `1px solid #${color}`,
+    };
+  }
+  return {
+    backgroundColor: `#${color}20`,
+    color: `#${color}`,
+    border: `1px solid #${color}40`,
+  };
+}

--- a/src/browser/components/app-shell.tsx
+++ b/src/browser/components/app-shell.tsx
@@ -348,7 +348,7 @@ function TabStatusIndicator({ status }: { status?: TabStatus }) {
       colorClass = "bg-yellow-500";
       title = "Checks running";
     } else if (status.checks === "success" || status.checks === "none") {
-      colorClass = "bg-green-500";
+      colorClass = "bg-success";
       title = status.mergeable ? "Ready to merge" : "Checks passed";
     }
   }

--- a/src/browser/components/app-shell.tsx
+++ b/src/browser/components/app-shell.tsx
@@ -122,7 +122,7 @@ export function AppShell() {
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background">
       {/* Native-style Tab Bar */}
-      <div className="h-9 bg-[#1a1a1a] flex items-center shrink-0 border-b border-border/50 app-drag-region">
+      <div className="h-9 bg-muted flex items-center shrink-0 border-b border-border/50 app-drag-region">
         {/* Logo with tooltip */}
         <div className="h-full flex items-center gap-1.5 px-3 shrink-0 app-no-drag">
           <HoverCard openDelay={200} closeDelay={100}>

--- a/src/browser/components/command-palette.tsx
+++ b/src/browser/components/command-palette.tsx
@@ -443,7 +443,7 @@ const FileItem = memo(function FileItem({
       </div>
       <div className="flex items-center gap-2 text-xs shrink-0">
         {file.status === "added" && (
-          <span className="text-green-500 group-data-[selected=true]:text-green-300">
+          <span className="text-success-fg group-data-[selected=true]:text-green-300">
             +{file.additions}
           </span>
         )}
@@ -454,7 +454,7 @@ const FileItem = memo(function FileItem({
         )}
         {file.status === "modified" && (
           <>
-            <span className="text-green-500 group-data-[selected=true]:text-green-300">
+            <span className="text-success-fg group-data-[selected=true]:text-green-300">
               +{file.additions}
             </span>
             <span className="text-red-500 group-data-[selected=true]:text-red-300">
@@ -468,7 +468,7 @@ const FileItem = memo(function FileItem({
           </span>
         )}
         {isViewed && (
-          <span className="px-1.5 py-0.5 bg-green-500/20 text-green-400 group-data-[selected=true]:bg-green-400/30 group-data-[selected=true]:text-green-200 rounded text-[10px]">
+          <span className="px-1.5 py-0.5 bg-success-muted-bg text-success-fg group-data-[selected=true]:bg-green-400/30 group-data-[selected=true]:text-green-200 rounded text-[10px]">
             viewed
           </span>
         )}

--- a/src/browser/components/file-header.tsx
+++ b/src/browser/components/file-header.tsx
@@ -39,7 +39,7 @@ export const FileHeader = memo(function FileHeader({
     switch (file.status) {
       case "added":
         return (
-          <span className="px-1.5 py-0.5 text-xs rounded bg-green-500/20 text-green-500 font-medium">
+          <span className="px-1.5 py-0.5 text-xs rounded bg-success-muted-bg text-success-fg font-medium">
             Added
           </span>
         );
@@ -71,7 +71,7 @@ export const FileHeader = memo(function FileHeader({
         </span>
         {fileStatusBadge}
         <span className="text-xs text-muted-foreground shrink-0">
-          <span className="text-green-500">+{file.additions}</span>{" "}
+          <span className="text-success-fg">+{file.additions}</span>{" "}
           <span className="text-red-500">−{file.deletions}</span>
         </span>
         {/* Navigation buttons */}
@@ -144,11 +144,11 @@ export const FileHeader = memo(function FileHeader({
           className={cn(
             "flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors shrink-0",
             isViewed
-              ? "bg-green-500/20 text-green-500 hover:bg-green-500/30"
+              ? "bg-success-muted-bg text-success-fg hover:bg-success-muted-bg"
               : "bg-muted hover:bg-muted/80 text-muted-foreground"
           )}
         >
-          <Check className={cn("w-4 h-4", isViewed && "text-green-500")} />
+          <Check className={cn("w-4 h-4", isViewed && "text-success-fg")} />
           {isViewed ? "Viewed" : "Mark as viewed"}
           <Keycap keyName="v" size="xs" className="ml-1" />
         </button>

--- a/src/browser/components/file-tree.tsx
+++ b/src/browser/components/file-tree.tsx
@@ -114,7 +114,7 @@ function buildTree(files: PullRequestFile[]): TreeNode[] {
 function getFileIcon(file: PullRequestFile) {
   switch (file.status) {
     case "added":
-      return <FilePlus className="w-4 h-4 text-green-500" />;
+      return <FilePlus className="w-4 h-4 text-success-fg" />;
     case "removed":
       return <FileMinus className="w-4 h-4 text-red-500" />;
     case "modified":
@@ -349,7 +349,7 @@ export function FileTree({
                       )}
                       <span className="truncate flex-1">{node.name}</span>
                       {allViewed && (
-                        <Check className="w-3 h-3 text-green-500 shrink-0" />
+                        <Check className="w-3 h-3 text-success-fg shrink-0" />
                       )}
                     </button>
                   </ContextMenuTrigger>
@@ -432,7 +432,7 @@ export function FileTree({
                           {commentCount}
                         </span>
                       )}
-                      {isViewed && <Check className="w-3 h-3 text-green-500" />}
+                      {isViewed && <Check className="w-3 h-3 text-success-fg" />}
                     </div>
                   </button>
                 </ContextMenuTrigger>

--- a/src/browser/components/home.tsx
+++ b/src/browser/components/home.tsx
@@ -25,7 +25,7 @@ import {
   Clock,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-import { cn } from "../cn";
+import { cn, labelStyles } from "../cn";
 import { Skeleton } from "../ui/skeleton";
 import { UserHoverCard } from "../ui/user-hover-card";
 import {
@@ -1466,11 +1466,7 @@ function PRListItem({ pr, onSelect }: PRListItemProps) {
             <span
               key={label.name}
               className="px-2 py-0.5 text-[11px] font-medium rounded-full hidden sm:inline-block"
-              style={{
-                backgroundColor: `#${label.color}20`,
-                color: `#${label.color}`,
-                border: `1px solid #${label.color}40`,
-              }}
+              style={labelStyles(label.color)}
             >
               {label.name}
             </span>

--- a/src/browser/components/pr-header.tsx
+++ b/src/browser/components/pr-header.tsx
@@ -47,7 +47,7 @@ export const PRHeader = memo(function PRHeader({
     : pr.state === "open"
       ? pr.draft
         ? "bg-gray-600"
-        : "bg-green-600"
+        : "bg-success"
       : "bg-red-600";
 
   return (
@@ -123,7 +123,7 @@ export const PRHeader = memo(function PRHeader({
       <div className="flex items-center gap-2 sm:gap-3 shrink-0">
         {/* Line diff stats */}
         <span className="text-xs hidden sm:inline">
-          <span className="text-green-500">+{pr.additions}</span>{" "}
+          <span className="text-success-fg">+{pr.additions}</span>{" "}
           <span className="text-red-500">−{pr.deletions}</span>
         </span>
 
@@ -158,7 +158,7 @@ function BranchBadge({ branch }: { branch: string }) {
         title="Copy branch name"
       >
         {copied ? (
-          <Check className="w-3 h-3 text-green-500" />
+          <Check className="w-3 h-3 text-success-fg" />
         ) : (
           <Copy className="w-3 h-3" />
         )}

--- a/src/browser/components/pr-overview.tsx
+++ b/src/browser/components/pr-overview.tsx
@@ -2751,7 +2751,7 @@ function ReviewThreadBox({
 
       {/* Code context (diff hunk) with syntax highlighting */}
       {diffHunkData && diffHunkData.type === "hunk" && (
-        <div className="bg-[#0d1117] border-b border-border overflow-x-auto">
+        <div className="bg-card border-b border-border overflow-x-auto">
           <table className="w-full text-xs font-mono">
             <tbody>
               {diffHunkData.lines.map((line, i) => (

--- a/src/browser/components/pr-overview.tsx
+++ b/src/browser/components/pr-overview.tsx
@@ -3560,7 +3560,7 @@ function MergeSection({
               onClick={handleToggleDropdown}
               disabled={merging}
               className={cn(
-                "px-2 py-2 rounded-r-md text-sm font-medium transition-colors border-l border-green-700",
+                "px-4 py-2 rounded-r-md text-sm font-medium transition-colors border-l border-green-700 self-stretch flex items-center",
                 canMergePR || bypassRules
                   ? "bg-green-600 text-white hover:bg-green-700"
                   : "bg-muted text-muted-foreground cursor-not-allowed"

--- a/src/browser/components/pr-overview.tsx
+++ b/src/browser/components/pr-overview.tsx
@@ -1460,7 +1460,7 @@ export const PROverview = memo(function PROverview() {
                           {branchDeleted && !isFromFork && (
                             <div className="shrink-0 flex items-center gap-3">
                               <span className="text-sm text-muted-foreground flex items-center gap-2">
-                                <Check className="w-4 h-4 text-green-400" />
+                                <Check className="w-4 h-4 text-success-fg" />
                                 Deleted{" "}
                                 <code className="px-1.5 py-0.5 bg-muted rounded text-xs">
                                   {pr.head.ref}
@@ -1527,7 +1527,7 @@ export const PROverview = memo(function PROverview() {
                       {branchDeleted && (
                         <div className="shrink-0 flex items-center gap-3">
                           <span className="text-sm text-muted-foreground flex items-center gap-2">
-                            <Check className="w-4 h-4 text-green-400" />
+                            <Check className="w-4 h-4 text-success-fg" />
                             Deleted{" "}
                             <code className="px-1.5 py-0.5 bg-muted rounded text-xs">
                               {pr.head.ref}
@@ -1557,7 +1557,7 @@ export const PROverview = memo(function PROverview() {
                         <button
                           onClick={handleReopenPR}
                           disabled={reopeningPR}
-                          className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 transition-colors disabled:opacity-50"
+                          className="flex items-center gap-2 px-4 py-2 bg-success text-white text-sm font-medium rounded-md hover:bg-success-hover transition-colors disabled:opacity-50"
                         >
                           {reopeningPR ? (
                             <Loader2 className="w-4 h-4 animate-spin" />
@@ -1608,7 +1608,7 @@ export const PROverview = memo(function PROverview() {
                         <button
                           onClick={handleAddComment}
                           disabled={!commentText.trim() || submittingComment}
-                          className="flex items-center gap-2 px-3 py-1.5 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 text-sm font-medium"
+                          className="flex items-center gap-2 px-3 py-1.5 bg-success text-white rounded-md hover:bg-success-hover transition-colors disabled:opacity-50 text-sm font-medium"
                         >
                           {submittingComment ? (
                             <Loader2 className="w-4 h-4 animate-spin" />
@@ -2225,7 +2225,7 @@ function LabelsSection({
                     >
                       <div className="w-4 h-4 flex items-center justify-center">
                         {isApplied && (
-                          <Check className="w-3.5 h-3.5 text-green-500" />
+                          <Check className="w-3.5 h-3.5 text-success-fg" />
                         )}
                       </div>
                       <span
@@ -2389,7 +2389,7 @@ function ReviewBox({ review }: { review: Review }) {
   // Icon color for timeline circle
   const iconColor =
     {
-      APPROVED: "text-green-500",
+      APPROVED: "text-success-fg",
       CHANGES_REQUESTED: "text-red-500",
       COMMENTED: "text-muted-foreground",
       DISMISSED: "text-muted-foreground",
@@ -2399,7 +2399,7 @@ function ReviewBox({ review }: { review: Review }) {
   // Border color for comment box
   const stateBorder =
     {
-      APPROVED: "border-green-500/30",
+      APPROVED: "border-success-muted-border",
       CHANGES_REQUESTED: "border-red-500/30",
       COMMENTED: "",
       DISMISSED: "",
@@ -2409,7 +2409,7 @@ function ReviewBox({ review }: { review: Review }) {
   // Header background for comment box
   const stateHeaderBg =
     {
-      APPROVED: "bg-green-500/10",
+      APPROVED: "bg-success-muted-bg",
       CHANGES_REQUESTED: "bg-red-500/10",
       COMMENTED: "",
       DISMISSED: "",
@@ -2517,7 +2517,7 @@ function ReviewStateIcon({
     switch (state) {
       case "APPROVED":
         return {
-          icon: <CheckCircle2 className="w-4 h-4 text-green-500" />,
+          icon: <CheckCircle2 className="w-4 h-4 text-success-fg" />,
           tooltip: "Approved this pull request",
         };
       case "CHANGES_REQUESTED":
@@ -2756,7 +2756,7 @@ function ReviewThreadBox({
                 <tr
                   key={i}
                   className={cn(
-                    line.type === "insert" && "bg-green-500/15",
+                    line.type === "insert" && "bg-success-muted-bg",
                     line.type === "delete" && "bg-red-500/15"
                   )}
                 >
@@ -2770,7 +2770,7 @@ function ReviewThreadBox({
                     <span
                       className={cn(
                         "select-none mr-1",
-                        line.type === "insert" && "text-green-400",
+                        line.type === "insert" && "text-success-fg",
                         line.type === "delete" && "text-red-400"
                       )}
                     >
@@ -2924,7 +2924,7 @@ function ReviewThreadBox({
                   <button
                     onClick={handleSubmitReply}
                     disabled={!replyText.trim() || submitting}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors disabled:opacity-50"
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-success text-white hover:bg-success-hover transition-colors disabled:opacity-50"
                   >
                     {submitting ? "Sending..." : "Reply"}
                   </button>
@@ -3172,7 +3172,7 @@ function MergeSection({
       className={cn(
         "border rounded-md overflow-hidden",
         overallStatus === "success"
-          ? "border-green-600"
+          ? "border-success"
           : overallStatus === "failure"
             ? "border-red-500"
             : "border-yellow-500"
@@ -3185,7 +3185,7 @@ function MergeSection({
           className="w-full flex items-center gap-3 p-4 hover:bg-card/30 transition-colors"
         >
           {reviewStatus === "success" ? (
-            <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+            <CheckCircle2 className="w-5 h-5 text-success-fg shrink-0" />
           ) : reviewStatus === "failure" ? (
             <XCircle className="w-5 h-5 text-red-500 shrink-0" />
           ) : (
@@ -3215,7 +3215,7 @@ function MergeSection({
             {/* Approval count row */}
             {approvalCount > 0 && (
               <div className="flex items-center gap-2 py-2">
-                <CheckCircle2 className="w-4 h-4 text-green-500" />
+                <CheckCircle2 className="w-4 h-4 text-success-fg" />
                 <span className="text-sm">
                   {approvalCount} approval{approvalCount !== 1 ? "s" : ""}
                 </span>
@@ -3306,7 +3306,7 @@ function MergeSection({
           className="w-full flex items-center gap-3 p-4 hover:bg-card/30 transition-colors"
         >
           {checkStatus === "success" ? (
-            <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+            <CheckCircle2 className="w-5 h-5 text-success-fg shrink-0" />
           ) : checkStatus === "failure" ? (
             <XCircle className="w-5 h-5 text-red-500 shrink-0" />
           ) : checkStatus === "action_required" ? (
@@ -3356,7 +3356,7 @@ function MergeSection({
                 ) : check.status === "in_progress" ? (
                   <Loader2 className="w-4 h-4 text-yellow-500 shrink-0 animate-spin" />
                 ) : check.conclusion === "success" ? (
-                  <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                  <CheckCircle2 className="w-4 h-4 text-success-fg shrink-0" />
                 ) : check.conclusion === "failure" ? (
                   <XCircle className="w-4 h-4 text-red-500 shrink-0" />
                 ) : check.conclusion === "skipped" ? (
@@ -3391,7 +3391,7 @@ function MergeSection({
             {checks.status.statuses.map((status) => (
               <div key={status.id} className="flex items-center gap-2 py-2">
                 {status.state === "success" ? (
-                  <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                  <CheckCircle2 className="w-4 h-4 text-success-fg shrink-0" />
                 ) : status.state === "failure" || status.state === "error" ? (
                   <XCircle className="w-4 h-4 text-red-500 shrink-0" />
                 ) : status.state === "pending" ? (
@@ -3427,7 +3427,7 @@ function MergeSection({
       <div className="border-b border-border">
         <div className="flex items-center gap-3 p-4">
           {conflictStatus === "success" ? (
-            <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+            <CheckCircle2 className="w-5 h-5 text-success-fg shrink-0" />
           ) : conflictStatus === "failure" ? (
             <XCircle className="w-5 h-5 text-red-500 shrink-0" />
           ) : (
@@ -3443,7 +3443,7 @@ function MergeSection({
             </p>
             <p className="text-xs text-muted-foreground">
               {updateBranchSuccess ? (
-                <span className="text-green-500">
+                <span className="text-success-fg">
                   Branch updated successfully!
                 </span>
               ) : updateBranchError ? (
@@ -3541,7 +3541,7 @@ function MergeSection({
               className={cn(
                 "flex items-center justify-center gap-2 px-4 py-2 rounded-l-md text-sm font-medium transition-colors",
                 canMergePR || bypassRules
-                  ? "bg-green-600 text-white hover:bg-green-700"
+                  ? "bg-success text-white hover:bg-success-hover"
                   : "bg-muted text-muted-foreground cursor-not-allowed"
               )}
             >
@@ -3558,9 +3558,9 @@ function MergeSection({
               onClick={handleToggleDropdown}
               disabled={merging}
               className={cn(
-                "px-4 py-2 rounded-r-md text-sm font-medium transition-colors border-l border-green-700 self-stretch flex items-center",
+                "px-4 py-2 rounded-r-md text-sm font-medium transition-colors border-l border-success-hover self-stretch flex items-center",
                 canMergePR || bypassRules
-                  ? "bg-green-600 text-white hover:bg-green-700"
+                  ? "bg-success text-white hover:bg-success-hover"
                   : "bg-muted text-muted-foreground cursor-not-allowed"
               )}
             >
@@ -3603,7 +3603,7 @@ function MergeSection({
                     >
                       <div className="flex items-center gap-2">
                         {mergeMethod === method ? (
-                          <Check className="w-4 h-4 text-green-500" />
+                          <Check className="w-4 h-4 text-success-fg" />
                         ) : (
                           <div className="w-4 h-4" />
                         )}
@@ -3681,7 +3681,7 @@ function CommitsTab({
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Check className="w-4 h-4 text-green-500" />
+            <Check className="w-4 h-4 text-success-fg" />
             <a
               href={`https://github.com/${owner}/${repo}/commit/${commit.sha}`}
               target="_blank"
@@ -3725,7 +3725,7 @@ function ChecksTab({
   ) {
     return (
       <div className="border border-border rounded-md p-8 text-center">
-        <CheckCircle2 className="w-12 h-12 text-green-500 mx-auto mb-3" />
+        <CheckCircle2 className="w-12 h-12 text-success-fg mx-auto mb-3" />
         <p className="text-muted-foreground">
           No checks configured for this repository
         </p>
@@ -3781,7 +3781,7 @@ function CheckRunItem({ check }: { check: CheckRun }) {
     }
     switch (check.conclusion) {
       case "success":
-        return <CheckCircle2 className="w-4 h-4 text-green-500" />;
+        return <CheckCircle2 className="w-4 h-4 text-success-fg" />;
       case "failure":
         return <XCircle className="w-4 h-4 text-red-500" />;
       default:
@@ -3820,7 +3820,7 @@ function StatusItem({
   const getIcon = () => {
     switch (status.state) {
       case "success":
-        return <CheckCircle2 className="w-4 h-4 text-green-500" />;
+        return <CheckCircle2 className="w-4 h-4 text-success-fg" />;
       case "failure":
       case "error":
         return <XCircle className="w-4 h-4 text-red-500" />;
@@ -3865,7 +3865,7 @@ function CheckStatusIcon({
 
   switch (status) {
     case "success":
-      return <CheckCircle2 className={cn(sizeClass, "text-green-500")} />;
+      return <CheckCircle2 className={cn(sizeClass, "text-success-fg")} />;
     case "failure":
       return <XCircle className={cn(sizeClass, "text-red-500")} />;
     case "action_required":
@@ -4766,7 +4766,7 @@ function TimelineItem({ event, pr }: TimelineItemProps) {
               reopened this pull request
             </span>
           ),
-          color: "text-green-400",
+          color: "text-success-fg",
         };
       }
 
@@ -4785,7 +4785,7 @@ function TimelineItem({ event, pr }: TimelineItemProps) {
               marked this pull request as ready for review
             </span>
           ),
-          color: "text-green-400",
+          color: "text-success-fg",
         };
       }
 

--- a/src/browser/components/pr-overview.tsx
+++ b/src/browser/components/pr-overview.tsx
@@ -43,7 +43,7 @@ import {
 } from "lucide-react";
 import { Skeleton } from "../ui/skeleton";
 import { Checkbox } from "../ui/checkbox";
-import { cn } from "../cn";
+import { cn, labelStyles } from "../cn";
 import { Markdown, MarkdownEditor } from "../ui/markdown";
 import { UserHoverCard, UserAvatar } from "../ui/user-hover-card";
 import {
@@ -2182,9 +2182,7 @@ function LabelsSection({
               key={label.name}
               className="px-2 py-0.5 text-xs font-medium rounded-full"
               style={{
-                backgroundColor: `#${label.color}20`,
-                color: `#${label.color}`,
-                border: `1px solid #${label.color}40`,
+                ...labelStyles(label.color),
               }}
             >
               {label.name}
@@ -4468,9 +4466,7 @@ function TimelineItem({ event, pr }: TimelineItemProps) {
               <span
                 className="px-2 py-0.5 text-xs font-medium rounded-full"
                 style={{
-                  backgroundColor: `#${labeled.label?.color}20`,
-                  color: `#${labeled.label?.color}`,
-                  border: `1px solid #${labeled.label?.color}40`,
+                  ...(labeled.label?.color ? labelStyles(labeled.label.color) : {}),
                 }}
               >
                 {labeled.label?.name}

--- a/src/browser/components/pr-review.tsx
+++ b/src/browser/components/pr-review.tsx
@@ -740,7 +740,7 @@ const KeybindsBar = memo(function KeybindsBar() {
         "shrink-0 border-t border-border px-3 py-2 min-h-[36px]",
         gotoLineMode && "bg-blue-500/10",
         (focusedCommentId || focusedPendingCommentId) && "bg-yellow-500/10",
-        commentingOnLine && "bg-green-500/10",
+        commentingOnLine && "bg-success-muted-bg",
         focusedSkipBlockIndex !== null && "bg-blue-500/10",
         !gotoLineMode &&
           !focusedCommentId &&
@@ -762,7 +762,7 @@ const KeybindsBar = memo(function KeybindsBar() {
                   className={cn(
                     "px-1.5 py-0.5 rounded text-xs font-medium",
                     gotoLineSide === "new"
-                      ? "bg-green-500/20 text-green-400"
+                      ? "bg-success-muted-bg text-success-fg"
                       : "bg-orange-500/20 text-orange-400"
                   )}
                 >
@@ -781,10 +781,10 @@ const KeybindsBar = memo(function KeybindsBar() {
             </>
           ) : commentingOnLine ? (
             <>
-              <span className="px-2 py-0.5 bg-green-500/20 text-green-400 rounded text-xs font-medium">
+              <span className="px-2 py-0.5 bg-success-muted-bg text-success-fg rounded text-xs font-medium">
                 COMMENT
               </span>
-              <span className="font-mono text-green-400">
+              <span className="font-mono text-success-fg">
                 L
                 {commentingOnLine.startLine
                   ? `${commentingOnLine.startLine}-`
@@ -2394,7 +2394,7 @@ const InlineCommentForm = memo(function InlineCommentForm({
           </span>
           <button
             onClick={startDeviceAuth}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-success text-white hover:bg-success-hover transition-colors"
           >
             Sign in with GitHub
           </button>
@@ -2461,7 +2461,7 @@ const InlineCommentForm = memo(function InlineCommentForm({
         <button
           onClick={handleSubmit}
           disabled={!text.trim() || submitting}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-success text-white hover:bg-success-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           style={{ fontFamily: "var(--font-sans)" }}
         >
           {submitting ? (
@@ -2580,7 +2580,7 @@ const CommentThread = memo(function CommentThread({
       className={cn(
         "mx-4 my-2 rounded-r-lg border-l-2",
         isResolved
-          ? "border-green-500/50 bg-green-500/5"
+          ? "border-success-muted-border bg-success-muted-bg"
           : "border-blue-500/50 bg-card/80"
       )}
     >
@@ -2588,14 +2588,14 @@ const CommentThread = memo(function CommentThread({
       <div className="flex items-center justify-between px-4 py-2 border-b border-border/30">
         <div className="flex items-center gap-2">
           {isResolved ? (
-            <CheckCircle2 className="w-4 h-4 text-green-500" />
+            <CheckCircle2 className="w-4 h-4 text-success-fg" />
           ) : (
             <Circle className="w-4 h-4 text-muted-foreground" />
           )}
           <span
             className={cn(
               "text-xs font-medium",
-              isResolved ? "text-green-500" : "text-muted-foreground"
+              isResolved ? "text-success-fg" : "text-muted-foreground"
             )}
           >
             {isResolved
@@ -2617,7 +2617,7 @@ const CommentThread = memo(function CommentThread({
                 "flex items-center gap-1 px-2 py-1 text-xs rounded transition-colors",
                 isResolved
                   ? "text-muted-foreground hover:text-foreground hover:bg-muted"
-                  : "text-green-500 hover:bg-green-500/10"
+                  : "text-success-fg hover:bg-success-muted-bg"
               )}
             >
               {resolving ? (
@@ -3468,14 +3468,14 @@ const SubmitReviewDropdown = memo(function SubmitReviewDropdown() {
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen} modal={false}>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors">
+        <button className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md bg-success text-white hover:bg-success-hover transition-colors">
           <span>Submit review</span>
           {pendingCount > 0 && (
-            <span className="px-1 py-0.5 text-[10px] bg-green-500/50 rounded">
+            <span className="px-1 py-0.5 text-[10px] bg-success/50 rounded">
               {pendingCount}
             </span>
           )}
-          <span className="px-1 py-0.5 text-[10px] bg-green-500/50 rounded font-mono">
+          <span className="px-1 py-0.5 text-[10px] bg-success/50 rounded font-mono">
             S
           </span>
           <ChevronsUpDown className="w-3.5 h-3.5 opacity-70" />
@@ -3606,7 +3606,7 @@ const SubmitReviewDropdown = memo(function SubmitReviewDropdown() {
                 <label className="flex items-start gap-3 cursor-pointer group">
                   <RadioGroupItem value="APPROVE" className="mt-0.5" />
                   <div className="flex flex-col gap-0.5">
-                    <span className="font-medium text-sm text-green-400">
+                    <span className="font-medium text-sm text-success-fg">
                       Approve
                     </span>
                     <span className="text-xs text-muted-foreground">
@@ -3681,7 +3681,7 @@ const SubmitReviewDropdown = memo(function SubmitReviewDropdown() {
             className={cn(
               "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md transition-colors disabled:opacity-50",
               reviewType === "APPROVE" &&
-                "bg-green-500/20 text-green-400 hover:bg-green-500/30 border border-green-500/30",
+                "bg-success-muted-bg text-success-fg hover:bg-success-muted-bg border border-success-muted-border",
               reviewType === "REQUEST_CHANGES" &&
                 "bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 border border-amber-500/30",
               reviewType === "COMMENT" &&
@@ -3926,7 +3926,7 @@ function DiffLineSkeleton({
 }) {
   const bgClass =
     type === "add"
-      ? "bg-green-500/5"
+      ? "bg-success-muted-bg"
       : type === "remove"
         ? "bg-orange-500/5"
         : "";

--- a/src/browser/components/pr-review.tsx
+++ b/src/browser/components/pr-review.tsx
@@ -1935,13 +1935,13 @@ const DiffLineRow = memo(function DiffLineRow({
 
     // Selection highlighting is now CSS-based via data-selected attribute
     if (isInCommentingRange) {
-      bgColor = "#19273e"; // opaque blue for commenting range
+      bgColor = "var(--diff-comment-range-bg)";
     } else if (line.type === "insert") {
-      bgColor = "#122218"; // opaque green
+      bgColor = "var(--diff-insert-bg)";
     } else if (line.type === "delete") {
-      bgColor = "#261710"; // opaque orange
+      bgColor = "var(--diff-delete-bg)";
     } else if (hasCommentRange) {
-      bgColor = "#1b1810"; // opaque yellow
+      bgColor = "var(--diff-comment-bg)";
     }
 
     const result: React.CSSProperties = {};
@@ -2013,9 +2013,9 @@ const DiffLineRow = memo(function DiffLineRow({
                 key={i}
                 className={cn(
                   seg.type === "insert" &&
-                    "bg-[var(--code-added)]/20 text-green-400",
+                    "bg-[var(--code-added)]/20 text-[var(--diff-insert-text)]",
                   seg.type === "delete" &&
-                    "bg-[var(--code-removed)]/20 text-orange-400 line-through decoration-orange-500/50",
+                    "bg-[var(--code-removed)]/20 text-[var(--diff-delete-text)] line-through decoration-[var(--diff-delete-text)]/50",
                   // Extra emphasis for tiny changes
                   isTinyChange &&
                     seg.type === "insert" &&
@@ -2139,13 +2139,13 @@ const SplitDiffLineRow = memo(function SplitDiffLineRow({
 
     let bgColor: string | undefined;
     if (isInCommentingRange) {
-      bgColor = "#19273e";
+      bgColor = "var(--diff-comment-range-bg)";
     } else if (isInsert) {
-      bgColor = "#122218";
+      bgColor = "var(--diff-insert-bg)";
     } else if (isDelete) {
-      bgColor = "#261710";
+      bgColor = "var(--diff-delete-bg)";
     } else if (hasCommentRange) {
-      bgColor = "#1b1810";
+      bgColor = "var(--diff-comment-bg)";
     }
 
     const bgStyle: React.CSSProperties = bgColor
@@ -2201,9 +2201,9 @@ const SplitDiffLineRow = memo(function SplitDiffLineRow({
                 <span
                   key={i}
                   className={cn(
-                    showInsert && "bg-[var(--code-added)]/20 text-green-400",
+                    showInsert && "bg-[var(--code-added)]/20 text-[var(--diff-insert-text)]",
                     showDelete &&
-                      "bg-[var(--code-removed)]/20 text-orange-400 line-through decoration-orange-500/50",
+                      "bg-[var(--code-removed)]/20 text-[var(--diff-delete-text)] line-through decoration-[var(--diff-delete-text)]/50",
                     isTinyChange &&
                       showInsert &&
                       "bg-[var(--code-added)]/40 font-semibold",

--- a/src/browser/components/welcome-dialog.tsx
+++ b/src/browser/components/welcome-dialog.tsx
@@ -15,6 +15,8 @@ import {
   Globe,
   ArrowRight,
   Clock,
+  Sun,
+  Moon,
 } from "lucide-react";
 import { BookmarkletDialog, useShowBookmarklet } from "./bookmarklet";
 import {
@@ -37,6 +39,7 @@ import { useCurrentUser } from "../contexts/github";
 import { useOpenPRReviewTab } from "../contexts/tabs";
 import { cn } from "../cn";
 import { isMac } from "../ui/keycap";
+import { useTheme } from "../contexts/theme";
 
 // ============================================================================
 // Animation Data
@@ -1319,6 +1322,7 @@ export function UserMenuButton({ className }: { className?: string }) {
   const currentUser = useCurrentUser()?.login ?? null;
   const showBookmarklet = useShowBookmarklet();
   const [bookmarkletOpen, setBookmarkletOpen] = useState(false);
+  const { theme, toggleTheme } = useTheme();
 
   // Anonymous mode - show read-only indicator with sign-in option
   if (isAnonymous && !isAuthenticated) {
@@ -1403,6 +1407,18 @@ export function UserMenuButton({ className }: { className?: string }) {
               <DropdownMenuSeparator />
             </>
           )}
+          <DropdownMenuItem
+            onClick={toggleTheme}
+            className="cursor-pointer"
+          >
+            {theme === "dark" ? (
+              <Sun className="w-4 h-4" />
+            ) : (
+              <Moon className="w-4 h-4" />
+            )}
+            {theme === "dark" ? "Light mode" : "Dark mode"}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
             onClick={logout}

--- a/src/browser/components/welcome-dialog.tsx
+++ b/src/browser/components/welcome-dialog.tsx
@@ -431,7 +431,7 @@ function LivePRListAnimation({ isActive }: { isActive: boolean }) {
               animationDelay: `${i * 50}ms`,
             }}
           >
-            <GitPullRequest className="w-3.5 h-3.5 text-green-500 shrink-0" />
+            <GitPullRequest className="w-3.5 h-3.5 text-success-fg shrink-0" />
             <div className="flex-1 min-w-0">
               <div className="text-[11px] font-medium text-foreground truncate">
                 {pr.title}
@@ -445,7 +445,7 @@ function LivePRListAnimation({ isActive }: { isActive: boolean }) {
               </div>
             </div>
             <div className="flex items-center gap-1.5 text-[9px] font-mono shrink-0">
-              <span className="text-green-400">+{pr.additions}</span>
+              <span className="text-success-fg">+{pr.additions}</span>
               <span className="text-red-400">−{pr.deletions}</span>
             </div>
           </div>
@@ -612,7 +612,7 @@ function FileNavigationAnimation({ isActive }: { isActive: boolean }) {
           </div>
           <div className="mt-1 h-1 bg-muted rounded-full overflow-hidden">
             <div
-              className="h-full bg-green-500 transition-all duration-300"
+              className="h-full bg-success transition-all duration-300"
               style={{ width: `${(viewedCount / 4) * 100}%` }}
             />
           </div>
@@ -629,12 +629,12 @@ function FileNavigationAnimation({ isActive }: { isActive: boolean }) {
               )}
             >
               {viewedFiles.has(i) ? (
-                <Check className="w-3 h-3 text-green-500 shrink-0" />
+                <Check className="w-3 h-3 text-success-fg shrink-0" />
               ) : (
                 <span
                   className={cn(
                     "w-1.5 h-1.5 rounded-full shrink-0",
-                    f.deletions > f.additions ? "bg-red-400" : "bg-green-400"
+                    f.deletions > f.additions ? "bg-red-400" : "bg-success"
                   )}
                 />
               )}
@@ -668,7 +668,7 @@ function FileNavigationAnimation({ isActive }: { isActive: boolean }) {
               isTransitioning ? "opacity-0" : "opacity-100"
             )}
           >
-            <span className="text-green-400">+{file.additions}</span>
+            <span className="text-success-fg">+{file.additions}</span>
             <span className="text-red-400">−{file.deletions}</span>
           </div>
         </div>
@@ -685,7 +685,7 @@ function FileNavigationAnimation({ isActive }: { isActive: boolean }) {
               className={cn(
                 "flex px-2",
                 line.type === "delete" && "bg-red-500/10",
-                line.type === "add" && "bg-green-500/10"
+                line.type === "add" && "bg-success-muted-bg"
               )}
             >
               <span className="w-7 text-right pr-2 text-muted-foreground/40 select-none shrink-0">
@@ -694,7 +694,7 @@ function FileNavigationAnimation({ isActive }: { isActive: boolean }) {
               <span
                 className={cn(
                   line.type === "delete" && "text-red-400",
-                  line.type === "add" && "text-green-400",
+                  line.type === "add" && "text-success-fg",
                   line.type === "context" && "text-muted-foreground"
                 )}
               >
@@ -787,7 +787,7 @@ function ReviewSubmitAnimation({ isActive }: { isActive: boolean }) {
       {/* Header showing PR context */}
       <div className="px-3 py-2 border-b border-border bg-muted/20">
         <div className="flex items-center gap-2">
-          <GitPullRequest className="w-4 h-4 text-green-500" />
+          <GitPullRequest className="w-4 h-4 text-success-fg" />
           <span className="text-xs font-medium">
             Fix authentication race condition
           </span>
@@ -801,11 +801,11 @@ function ReviewSubmitAnimation({ isActive }: { isActive: boolean }) {
       <div className="flex-1 flex flex-col items-center justify-center p-4">
         {step === "success" ? (
           <div className="flex flex-col items-center gap-3 animate-in fade-in zoom-in-95 duration-300">
-            <div className="w-16 h-16 rounded-full bg-green-500/20 flex items-center justify-center">
-              <CheckCircle2 className="w-10 h-10 text-green-500 animate-in zoom-in-50 duration-500" />
+            <div className="w-16 h-16 rounded-full bg-success-muted-bg flex items-center justify-center">
+              <CheckCircle2 className="w-10 h-10 text-success-fg animate-in zoom-in-50 duration-500" />
             </div>
             <div className="text-center">
-              <div className="text-sm font-medium text-green-400">
+              <div className="text-sm font-medium text-success-fg">
                 Approved!
               </div>
               <div className="text-[11px] text-muted-foreground mt-0.5">
@@ -818,12 +818,12 @@ function ReviewSubmitAnimation({ isActive }: { isActive: boolean }) {
             {/* File summary */}
             <div className="flex items-center gap-3 mb-4 text-[11px] text-muted-foreground">
               <div className="flex items-center gap-1">
-                <Check className="w-3.5 h-3.5 text-green-500" />
+                <Check className="w-3.5 h-3.5 text-success-fg" />
                 <span>4 files reviewed</span>
               </div>
               <span>•</span>
               <div className="flex items-center gap-1">
-                <span className="text-green-400">+89</span>
+                <span className="text-success-fg">+89</span>
                 <span className="text-red-400">−260</span>
               </div>
             </div>
@@ -834,7 +834,7 @@ function ReviewSubmitAnimation({ isActive }: { isActive: boolean }) {
                 className={cn(
                   "flex items-center gap-2 px-4 py-2 rounded-md text-xs font-medium transition-all duration-200",
                   selectedAction === "approve"
-                    ? "bg-green-500 text-white scale-105 shadow-lg shadow-green-500/25"
+                    ? "bg-success text-white scale-105 shadow-lg shadow-green-500/25"
                     : "bg-muted/50 text-muted-foreground hover:bg-muted"
                 )}
               >
@@ -1175,7 +1175,7 @@ export function WelcomeDialog() {
                     </span>
                     <span className="p-1 rounded bg-muted group-hover:bg-muted/80 transition-colors">
                       {copied ? (
-                        <Check className="w-4 h-4 text-green-500" />
+                        <Check className="w-4 h-4 text-success-fg" />
                       ) : (
                         <Copy className="w-4 h-4 text-muted-foreground" />
                       )}
@@ -1281,7 +1281,7 @@ export function WelcomeDialog() {
                     samplePRsDisabled && "cursor-not-allowed"
                   )}
                 >
-                  <GitPullRequest className="w-4 h-4 mt-0.5 text-green-500 shrink-0" />
+                  <GitPullRequest className="w-4 h-4 mt-0.5 text-success-fg shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className="font-mono text-[11px] text-muted-foreground">
                       {pr.owner}/{pr.repo}
@@ -1291,7 +1291,7 @@ export function WelcomeDialog() {
                     </div>
                     <div className="flex items-center gap-2 mt-1.5 text-[11px] text-muted-foreground">
                       <span>{pr.files} files</span>
-                      <span className="text-green-500">+{pr.additions}</span>
+                      <span className="text-success-fg">+{pr.additions}</span>
                       <span className="text-red-500">−{pr.deletions}</span>
                     </div>
                   </div>

--- a/src/browser/contexts/theme.tsx
+++ b/src/browser/contexts/theme.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import type { ReactNode } from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const THEME_STORAGE_KEY = "theme";
+
+function getInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // localStorage unavailable
+  }
+  return "dark";
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.remove("dark", "light");
+  root.classList.add(theme);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+  return ctx;
+}

--- a/src/browser/index.css
+++ b/src/browser/index.css
@@ -95,6 +95,11 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-success: var(--success-emphasis);
+  --color-success-hover: var(--success-emphasis-hover);
+  --color-success-fg: var(--success-fg);
+  --color-success-muted-bg: var(--success-muted-bg);
+  --color-success-muted-border: var(--success-muted-border);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -145,6 +150,13 @@
   --diff-insert-text: oklch(0.792 0.209 151.711);
   --diff-delete-text: oklch(0.792 0.117 56.856);
 
+  /* Success (green) semantic colors — dark mode */
+  --success-emphasis: #238636;
+  --success-emphasis-hover: #2ea043;
+  --success-fg: #3fb950;
+  --success-muted-bg: rgba(63, 185, 80, 0.1);
+  --success-muted-border: rgba(63, 185, 80, 0.3);
+
   --font-sans:
     "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
     Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
@@ -194,6 +206,13 @@
   /* Diff inline segment text colors */
   --diff-insert-text: #1a7f37;
   --diff-delete-text: #d1242f;
+
+  /* Success (green) semantic colors — GitHub Primer light */
+  --success-emphasis: #1f883d;
+  --success-emphasis-hover: #1a7f37;
+  --success-fg: #1a7f37;
+  --success-muted-bg: #dafbe1;
+  --success-muted-border: rgba(74, 194, 107, 0.4);
 }
 
 @layer base {

--- a/src/browser/index.css
+++ b/src/browser/index.css
@@ -152,47 +152,48 @@
 }
 
 .light {
-  --background: oklch(0.985 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.922 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.922 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.922 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0 0 0 / 10%);
-  --input: oklch(0 0 0 / 15%);
-  --ring: oklch(0.708 0 0);
-  --sidebar: oklch(0.965 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.922 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0 0 0 / 10%);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* GitHub Primer light theme palette */
+  --background: #ffffff;
+  --foreground: #1f2328;
+  --card: #ffffff;
+  --card-foreground: #1f2328;
+  --popover: #ffffff;
+  --popover-foreground: #1f2328;
+  --primary: #1f2328;
+  --primary-foreground: #ffffff;
+  --secondary: #f6f8fa;
+  --secondary-foreground: #1f2328;
+  --muted: #f6f8fa;
+  --muted-foreground: #656d76;
+  --accent: #f6f8fa;
+  --accent-foreground: #1f2328;
+  --destructive: #d1242f;
+  --border: #d0d7de;
+  --input: #d0d7de;
+  --ring: #0969da;
+  --sidebar: #f6f8fa;
+  --sidebar-foreground: #1f2328;
+  --sidebar-primary: #0969da;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #eaeef2;
+  --sidebar-accent-foreground: #1f2328;
+  --sidebar-border: #d0d7de;
+  --sidebar-ring: #0969da;
 
   /* Scrollbar colors */
-  --scrollbar-track: oklch(0.95 0 0);
-  --scrollbar-thumb: oklch(0.75 0 0);
-  --scrollbar-thumb-hover: oklch(0.65 0 0);
+  --scrollbar-track: #f6f8fa;
+  --scrollbar-thumb: #c1c8cd;
+  --scrollbar-thumb-hover: #9ea7b0;
 
-  /* Diff line background colors */
-  --diff-insert-bg: #ccf0d4;
-  --diff-delete-bg: #fdd8d3;
-  --diff-comment-range-bg: #dbeafe;
-  --diff-comment-bg: #fef9c3;
+  /* Diff line background colors (GitHub diff palette) */
+  --diff-insert-bg: #dafbe1;
+  --diff-delete-bg: #ffebe9;
+  --diff-comment-range-bg: #ddf4ff;
+  --diff-comment-bg: #fff8c5;
 
   /* Diff inline segment text colors */
-  --diff-insert-text: oklch(0.448 0.119 151.711);
-  --diff-delete-text: oklch(0.495 0.155 27.325);
+  --diff-insert-text: #1a7f37;
+  --diff-delete-text: #d1242f;
 }
 
 @layer base {
@@ -353,7 +354,7 @@
 /* Light mode diff selection overrides */
 .light .diff-line-row[data-selected="true"],
 .light .split-diff-side[data-selected="true"] {
-  background: linear-gradient(#dbeafe, #dbeafe) !important;
+  background: linear-gradient(#ddf4ff, #ddf4ff) !important;
 }
 
 /* ============================================================================
@@ -660,40 +661,40 @@
    ============================================================================ */
 
 .light .markdown-body a {
-  color: oklch(0.45 0.2 250);
+  color: #0969da;
 }
 
 .light .markdown-body code {
-  background-color: oklch(0.92 0.01 260 / 50%);
+  background-color: #eff1f3;
 }
 
 .light .markdown-body pre {
-  background-color: oklch(0.95 0.01 260 / 60%);
-  border: 1px solid oklch(0 0 0 / 8%);
+  background-color: #f6f8fa;
+  border: 1px solid #d0d7de;
 }
 
 .light .markdown-body table th {
-  background-color: oklch(0.95 0 0);
+  background-color: #f6f8fa;
 }
 
 .light .markdown-body table tr:nth-child(2n) {
-  background-color: oklch(0.97 0 0 / 50%);
+  background-color: #f6f8fa80;
 }
 
 .light .markdown-body .hljs {
-  color: #24292e;
+  color: #1f2328;
 }
 
 .light .markdown-body .hljs-comment,
 .light .markdown-body .hljs-quote {
-  color: #6a737d;
+  color: #6e7781;
   font-style: italic;
 }
 
 .light .markdown-body .hljs-keyword,
 .light .markdown-body .hljs-selector-tag,
 .light .markdown-body .hljs-addition {
-  color: #d73a49;
+  color: #cf222e;
 }
 
 .light .markdown-body .hljs-number,
@@ -702,7 +703,7 @@
 .light .markdown-body .hljs-literal,
 .light .markdown-body .hljs-doctag,
 .light .markdown-body .hljs-regexp {
-  color: #032f62;
+  color: #0a3069;
 }
 
 .light .markdown-body .hljs-title,
@@ -710,7 +711,7 @@
 .light .markdown-body .hljs-name,
 .light .markdown-body .hljs-selector-id,
 .light .markdown-body .hljs-selector-class {
-  color: #6f42c1;
+  color: #8250df;
 }
 
 .light .markdown-body .hljs-attribute,
@@ -719,7 +720,7 @@
 .light .markdown-body .hljs-template-variable,
 .light .markdown-body .hljs-class .hljs-title,
 .light .markdown-body .hljs-type {
-  color: #005cc5;
+  color: #0550ae;
 }
 
 .light .markdown-body .hljs-symbol,
@@ -730,14 +731,14 @@
 .light .markdown-body .hljs-selector-attr,
 .light .markdown-body .hljs-selector-pseudo,
 .light .markdown-body .hljs-link {
-  color: #e36209;
+  color: #953800;
 }
 
 .light .markdown-body .hljs-built_in,
 .light .markdown-body .hljs-deletion {
-  color: #b31d28;
+  color: #82071e;
 }
 
 .light .markdown-body .hljs-formula {
-  background-color: oklch(0.95 0 0);
+  background-color: #f6f8fa;
 }

--- a/src/browser/index.css
+++ b/src/browser/index.css
@@ -135,10 +135,64 @@
   --scrollbar-thumb: oklch(0.35 0 0);
   --scrollbar-thumb-hover: oklch(0.45 0 0);
 
+  /* Diff line background colors */
+  --diff-insert-bg: #122218;
+  --diff-delete-bg: #261710;
+  --diff-comment-range-bg: #19273e;
+  --diff-comment-bg: #1b1810;
+
+  /* Diff inline segment text colors */
+  --diff-insert-text: oklch(0.792 0.209 151.711);
+  --diff-delete-text: oklch(0.792 0.117 56.856);
+
   --font-sans:
     "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
     Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   --font-mono: "Geist Mono", "Fira Code", "Fira Mono", ui-monospace, monospace;
+}
+
+.light {
+  --background: oklch(0.985 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.922 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.922 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.922 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0 0 0 / 10%);
+  --input: oklch(0 0 0 / 15%);
+  --ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.965 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.922 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0 0 0 / 10%);
+  --sidebar-ring: oklch(0.708 0 0);
+
+  /* Scrollbar colors */
+  --scrollbar-track: oklch(0.95 0 0);
+  --scrollbar-thumb: oklch(0.75 0 0);
+  --scrollbar-thumb-hover: oklch(0.65 0 0);
+
+  /* Diff line background colors */
+  --diff-insert-bg: #ccf0d4;
+  --diff-delete-bg: #fdd8d3;
+  --diff-comment-range-bg: #dbeafe;
+  --diff-comment-bg: #fef9c3;
+
+  /* Diff inline segment text colors */
+  --diff-insert-text: oklch(0.448 0.119 151.711);
+  --diff-delete-text: oklch(0.495 0.155 27.325);
 }
 
 @layer base {
@@ -294,6 +348,12 @@
     inset -2px 0 0 rgb(59, 130, 246),
     inset 0 2px 0 rgb(59, 130, 246),
     inset 0 -2px 0 rgb(59, 130, 246) !important;
+}
+
+/* Light mode diff selection overrides */
+.light .diff-line-row[data-selected="true"],
+.light .split-diff-side[data-selected="true"] {
+  background: linear-gradient(#dbeafe, #dbeafe) !important;
 }
 
 /* ============================================================================
@@ -593,4 +653,91 @@
 
 .markdown-body .hljs-strong {
   font-weight: bold;
+}
+
+/* ============================================================================
+   Light mode overrides for Markdown Body
+   ============================================================================ */
+
+.light .markdown-body a {
+  color: oklch(0.45 0.2 250);
+}
+
+.light .markdown-body code {
+  background-color: oklch(0.92 0.01 260 / 50%);
+}
+
+.light .markdown-body pre {
+  background-color: oklch(0.95 0.01 260 / 60%);
+  border: 1px solid oklch(0 0 0 / 8%);
+}
+
+.light .markdown-body table th {
+  background-color: oklch(0.95 0 0);
+}
+
+.light .markdown-body table tr:nth-child(2n) {
+  background-color: oklch(0.97 0 0 / 50%);
+}
+
+.light .markdown-body .hljs {
+  color: #24292e;
+}
+
+.light .markdown-body .hljs-comment,
+.light .markdown-body .hljs-quote {
+  color: #6a737d;
+  font-style: italic;
+}
+
+.light .markdown-body .hljs-keyword,
+.light .markdown-body .hljs-selector-tag,
+.light .markdown-body .hljs-addition {
+  color: #d73a49;
+}
+
+.light .markdown-body .hljs-number,
+.light .markdown-body .hljs-string,
+.light .markdown-body .hljs-meta .hljs-meta-string,
+.light .markdown-body .hljs-literal,
+.light .markdown-body .hljs-doctag,
+.light .markdown-body .hljs-regexp {
+  color: #032f62;
+}
+
+.light .markdown-body .hljs-title,
+.light .markdown-body .hljs-section,
+.light .markdown-body .hljs-name,
+.light .markdown-body .hljs-selector-id,
+.light .markdown-body .hljs-selector-class {
+  color: #6f42c1;
+}
+
+.light .markdown-body .hljs-attribute,
+.light .markdown-body .hljs-attr,
+.light .markdown-body .hljs-variable,
+.light .markdown-body .hljs-template-variable,
+.light .markdown-body .hljs-class .hljs-title,
+.light .markdown-body .hljs-type {
+  color: #005cc5;
+}
+
+.light .markdown-body .hljs-symbol,
+.light .markdown-body .hljs-bullet,
+.light .markdown-body .hljs-subst,
+.light .markdown-body .hljs-meta,
+.light .markdown-body .hljs-meta .hljs-keyword,
+.light .markdown-body .hljs-selector-attr,
+.light .markdown-body .hljs-selector-pseudo,
+.light .markdown-body .hljs-link {
+  color: #e36209;
+}
+
+.light .markdown-body .hljs-built_in,
+.light .markdown-body .hljs-deletion {
+  color: #b31d28;
+}
+
+.light .markdown-body .hljs-formula {
+  background-color: oklch(0.95 0 0);
 }

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -4,33 +4,36 @@ import { AuthProvider } from "./contexts/auth";
 import { GitHubProvider } from "./contexts/github";
 import { TelemetryProvider } from "./contexts/telemetry";
 import { TabProvider } from "./contexts/tabs";
+import { ThemeProvider } from "./contexts/theme";
 import { CommandPaletteProvider } from "./components/command-palette";
 import { AppShell } from "./components/app-shell";
 import { WelcomeDialog } from "./components/welcome-dialog";
 import "./index.css";
 
 createRoot(document.getElementById("app")!).render(
-  <AuthProvider>
-    <GitHubProvider>
-      <TelemetryProvider>
-        <BrowserRouter>
-          <TabProvider>
-            <CommandPaletteProvider>
-              <Routes>
-                {/* Home */}
-                <Route path="/" element={<AppShell />} />
-                {/* PR review - URL like /:owner/:repo/pull/:number */}
-                <Route
-                  path="/:owner/:repo/pull/:number"
-                  element={<AppShell />}
-                />
-              </Routes>
-              {/* Auth dialog - shown when not authenticated */}
-              <WelcomeDialog />
-            </CommandPaletteProvider>
-          </TabProvider>
-        </BrowserRouter>
-      </TelemetryProvider>
-    </GitHubProvider>
-  </AuthProvider>
+  <ThemeProvider>
+    <AuthProvider>
+      <GitHubProvider>
+        <TelemetryProvider>
+          <BrowserRouter>
+            <TabProvider>
+              <CommandPaletteProvider>
+                <Routes>
+                  {/* Home */}
+                  <Route path="/" element={<AppShell />} />
+                  {/* PR review - URL like /:owner/:repo/pull/:number */}
+                  <Route
+                    path="/:owner/:repo/pull/:number"
+                    element={<AppShell />}
+                  />
+                </Routes>
+                {/* Auth dialog - shown when not authenticated */}
+                <WelcomeDialog />
+              </CommandPaletteProvider>
+            </TabProvider>
+          </BrowserRouter>
+        </TelemetryProvider>
+      </GitHubProvider>
+    </AuthProvider>
+  </ThemeProvider>
 );


### PR DESCRIPTION
Add a light mode theme that users can toggle from the profile dropdown menu (avatar click). Preference persists via localStorage.

Changes:
  - New ThemeContext manages dark/light state and toggles .dark/.light class on the document root
  - Light mode CSS variables for all theme colors (backgrounds, text, borders, scrollbars, diff highlights, markdown syntax highlighting)
  - Replaced hardcoded dark hex colors in diff views with CSS variables so insert/delete/comment-range backgrounds adapt to theme
  - Replaced hardcoded bg-[#1a1a1a] and bg-[#0d1117] in app-shell and pr-overview with semantic classes (bg-muted, bg-card)
  - Sun/Moon toggle added to the user menu